### PR TITLE
fix CMakeLists spelling error

### DIFF
--- a/sample/hub/CMakeLists.txt
+++ b/sample/hub/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-set(DEMO_NAME hub_smaple)
+set(DEMO_NAME hub_sample)
 add_executable(${DEMO_NAME} main.c)
 target_link_libraries(${DEMO_NAME}
         PRIVATE

--- a/sample/lidar/CMakeLists.txt
+++ b/sample/lidar/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-set(DEMO_NAME lidar_smaple)
+set(DEMO_NAME lidar_sample)
 add_executable(${DEMO_NAME} main.c)
 target_link_libraries(${DEMO_NAME}
         PRIVATE


### PR DESCRIPTION
The CMakeLists file defines the output of the sample programs to be "hub_smaple" and "lidar_smaple". This is confusing, because the docs say that the sample programs should be called "hub_sample" and "lidar_sample". I have fixed this spelling error so that the docs are correct and the sample programs compile to "hub_sample" and "lidar_sample".