### PR TITLE
Bug Fix: Failed to connect lidar when multi adapter presented with fi…

### DIFF
--- a/sdk_core/src/base/network_util.cpp
+++ b/sdk_core/src/base/network_util.cpp
@@ -99,20 +99,23 @@ bool FindLocalIP(const struct sockaddr_in &client_addr, uint32_t &local_ip) {
 
   IP_ADAPTER_INFO *pAdapter = reinterpret_cast<IP_ADAPTER_INFO *>(pAdapterInfo.get());
   if (NO_ERROR == dlRetVal && pAdapter != NULL) {
-    while (GetAdapterState(pAdapter)) {
-      std::string str_ip = pAdapter->IpAddressList.IpAddress.String;
-      std::string str_mask = pAdapter->IpAddressList.IpMask.String;
-      ULONG host_ip = inet_addr(const_cast<char *>(str_ip.c_str()));
-      ULONG host_mask = inet_addr(const_cast<char *>(str_mask.c_str()));
+	  while (pAdapter != NULL) {
+		  if (GetAdapterState(pAdapter)) {
+			  std::string str_ip = pAdapter->IpAddressList.IpAddress.String;
+			  std::string str_mask = pAdapter->IpAddressList.IpMask.String;
+			  ULONG host_ip = inet_addr(const_cast<char *>(str_ip.c_str()));
+			  ULONG host_mask = inet_addr(const_cast<char *>(str_mask.c_str()));
 
-      if ((host_ip & host_mask) ==
-        (client_addr.sin_addr.S_un.S_addr & host_mask)) {
-        local_ip = host_ip;
-        found = true;
-        break;
-      }
-      pAdapter = pAdapter->Next;
-    }
+			  if ((host_ip & host_mask) ==
+				  (client_addr.sin_addr.S_un.S_addr & host_mask)) {
+				  local_ip = host_ip;
+				  found = true;
+				  break;
+			  }
+		  }
+
+		  pAdapter = pAdapter->Next;
+	  }
   }
   return found;
 }

--- a/sdk_core/src/base/network_util.cpp
+++ b/sdk_core/src/base/network_util.cpp
@@ -99,24 +99,25 @@ bool FindLocalIP(const struct sockaddr_in &client_addr, uint32_t &local_ip) {
 
   IP_ADAPTER_INFO *pAdapter = reinterpret_cast<IP_ADAPTER_INFO *>(pAdapterInfo.get());
   if (NO_ERROR == dlRetVal && pAdapter != NULL) {
-	  while (pAdapter != NULL) {
-		  if (GetAdapterState(pAdapter)) {
-			  std::string str_ip = pAdapter->IpAddressList.IpAddress.String;
-			  std::string str_mask = pAdapter->IpAddressList.IpMask.String;
-			  ULONG host_ip = inet_addr(const_cast<char *>(str_ip.c_str()));
-			  ULONG host_mask = inet_addr(const_cast<char *>(str_mask.c_str()));
+    while (pAdapter != NULL) {
+      if (GetAdapterState(pAdapter)) {
+	std::string str_ip = pAdapter->IpAddressList.IpAddress.String;
+	std::string str_mask = pAdapter->IpAddressList.IpMask.String;
+	ULONG host_ip = inet_addr(const_cast<char *>(str_ip.c_str()));
+	ULONG host_mask = inet_addr(const_cast<char *>(str_mask.c_str()));
 
-			  if ((host_ip & host_mask) ==
-				  (client_addr.sin_addr.S_un.S_addr & host_mask)) {
-				  local_ip = host_ip;
-				  found = true;
-				  break;
-			  }
-		  }
+	if ((host_ip & host_mask) ==
+	  (client_addr.sin_addr.S_un.S_addr & host_mask)) {
+	  local_ip = host_ip;
+	  found = true;
+	  break;
+	}
+      }
 
-		  pAdapter = pAdapter->Next;
-	  }
+      pAdapter = pAdapter->Next;
+    }
   }
+
   return found;
 }
 #else


### PR DESCRIPTION
…rst one disconnected

Bug Description:
When you have more than one network adater on your compter, this part of the code is supposed to find one that is connecting and working fine and obtain its ip address for handshaking request.
However, it failed to do so when the first network adapter is not connected. Thus GetAdapterState returns false and we stopped trying on the other adapters.

Fix:
Try each adapter, if it is not working, we try the next one. Either we find one and we move onto the following process or we find none and quit.