### PR TITLE
Add string header to fix build error in Visual Studio 2019

### DIFF
--- a/sample_cc/hub/lds_hub.h
+++ b/sample_cc/hub/lds_hub.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "livox_def.h"
 #include "livox_sdk.h"

--- a/sample_cc/lidar/lds_lidar.h
+++ b/sample_cc/lidar/lds_lidar.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "livox_def.h"
 #include "livox_sdk.h"

--- a/sample_cc/lidar_utc_sync/lds_lidar.h
+++ b/sample_cc/lidar_utc_sync/lds_lidar.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "livox_def.h"
 #include "livox_sdk.h"

--- a/sample_cc/lidar_utc_sync/synchro.h
+++ b/sample_cc/lidar_utc_sync/synchro.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <thread>
 #include <vector>
+#include <string>
 #include <functional>
 #ifdef WIN32
 #include <Windows.h>


### PR DESCRIPTION
This pull-request will fix build error in Visual Studio 2019 (16.4.3) by add include string header to these files.

```
> Livox-SDK\sample_cc\hub\lds_hub.h(81,41): error C2065: 'string': undeclared identifier
> Livox-SDK\sample_cc\lidar\lds_lidar.h(83,43): error C2065: 'string': undeclared identifier
> Livox-SDK\sample_cc\lidar_utc_sync\lds_lidar.h(60,43): error C2065: 'string': undeclared identifier
> Livox-SDK\sample_cc\lidar_utc_sync\synchro.cpp(66,39): error C2065: 'string': undeclared identifier
```