### PR TITLE
Feature. Add pri files for Qt integration.

### DIFF
--- a/sdk_core/include/sdk_core_include.pri
+++ b/sdk_core/include/sdk_core_include.pri
@@ -1,0 +1,6 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+

--- a/sdk_core/sdk_core.pri
+++ b/sdk_core/sdk_core.pri
@@ -1,0 +1,10 @@
+
+include( $$PWD/include/sdk_core_include.pri )
+include( $$PWD/src/sdk_core_src.pri )
+
+INCLUDEPATH += $$PWD/include/third_party/spdlog
+
+CONFIG      *= link_pkgconfig
+PKGCONFIG   *= apr-1
+
+LIBS        *= -lboost_system

--- a/sdk_core/src/base/src_base.pri
+++ b/sdk_core/src/base/src_base.pri
@@ -1,0 +1,6 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+

--- a/sdk_core/src/comm/src_comm.pri
+++ b/sdk_core/src/comm/src_comm.pri
@@ -1,0 +1,6 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+

--- a/sdk_core/src/command_handler/src_command_handler.pri
+++ b/sdk_core/src/command_handler/src_command_handler.pri
@@ -1,0 +1,6 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+

--- a/sdk_core/src/data_handler/src_data_handler.pri
+++ b/sdk_core/src/data_handler/src_data_handler.pri
@@ -1,0 +1,6 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+

--- a/sdk_core/src/sdk_core_src.pri
+++ b/sdk_core/src/sdk_core_src.pri
@@ -1,0 +1,11 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+include( $$PWD/command_handler/src_command_handler.pri )
+include( $$PWD/data_handler/src_data_handler.pri )
+include( $$PWD/base/src_base.pri )
+include( $$PWD/comm/src_comm.pri )
+
+include( $$PWD/third_party/FastCRC/FastCRC.pri )

--- a/sdk_core/src/third_party/FastCRC/FastCRC.pri
+++ b/sdk_core/src/third_party/FastCRC/FastCRC.pri
@@ -1,0 +1,7 @@
+
+INCLUDEPATH += $$PWD
+HEADERS     += $$files( $$PWD/*.h   )
+HEADERS     += $$files( $$PWD/*.hpp )
+SOURCES     += $$files( $$PWD/*.cpp )
+
+


### PR DESCRIPTION
Add Livox SDK Qt integration.

Only add to your project .pro file:
SDK_DIR = $$PWD/Livox-SDK
include( $$SDK_DIR/sdk_core/sdk_core.pri )

