### PR TITLE
fix: strncpy reads out of bounds

### DIFF
--- a/sdk_core/src/device_discovery.cpp
+++ b/sdk_core/src/device_discovery.cpp
@@ -184,7 +184,7 @@ void DeviceDiscovery::OnBroadcast(const CommPacket &packet, apr_sockaddr_t *addr
   }
 
   ++port_count;
-  strncpy(lidar_info.broadcast_code, broadcast_code.c_str(), sizeof(lidar_info.broadcast_code));
+  strncpy(lidar_info.broadcast_code, broadcast_code.c_str(), sizeof(lidar_info.broadcast_code)-1);
   lidar_info.cmd_port = kListenPort + kCmdPortOffset + port_count;
   lidar_info.data_port = kListenPort + kDataPortOffset + port_count;
   lidar_info.sensor_port = kListenPort + kSensorPortOffset + port_count;

--- a/sdk_core/src/device_manager.cpp
+++ b/sdk_core/src/device_manager.cpp
@@ -207,7 +207,7 @@ bool DeviceManager::AddListeningDevice(const string &broadcast_code, DeviceMode 
     devices_[kHubDefaultHandle].connected = false;
     strncpy(devices_[kHubDefaultHandle].info.broadcast_code,
             broadcast_code.c_str(),
-            sizeof(devices_[kHubDefaultHandle].info.broadcast_code));
+            sizeof(devices_[kHubDefaultHandle].info.broadcast_code)-1);
     devices_[kHubDefaultHandle].info.handle = kHubDefaultHandle;
     return true;
   }
@@ -216,7 +216,7 @@ bool DeviceManager::AddListeningDevice(const string &broadcast_code, DeviceMode 
     if (strlen(ite->info.broadcast_code) == 0) {
       handle = ite - devices_.begin();
       ite->connected = false;
-      strncpy(ite->info.broadcast_code, broadcast_code.c_str(), sizeof(ite->info.broadcast_code));
+      strncpy(ite->info.broadcast_code, broadcast_code.c_str(), sizeof(ite->info.broadcast_code)-1);
       ite->info.handle = handle;
       return true;
     } else if (strncmp(ite->info.broadcast_code, broadcast_code.c_str(), sizeof(ite->info.broadcast_code)) == 0) {


### PR DESCRIPTION
There are several out of bounds strncpy calls. This commit fixes them. On gcc 8.3.0 the SDK does not compile without this fix and gives the error:

```
/home/gekko/Livox-SDK/sdk_core/src/device_manager.cpp: In member function ‘bool livox::DeviceManager::AddListeningDevice(const string&, livox::DeviceM
ode, uint8_t&)’:                                                                                                                                      
/home/gekko/Livox-SDK/sdk_core/src/device_manager.cpp:177:14: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 16 equals destination
 size [-Werror=stringop-truncation]                                                                                                                   
       strncpy(ite->info.broadcast_code, broadcast_code.c_str(), sizeof(ite->info.broadcast_code));                                              
       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    
/home/gekko/Livox-SDK/sdk_core/src/device_manager.cpp:166:12: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 16 equals destination
 size [-Werror=stringop-truncation]                                                                       
     strncpy(devices_[kHubDefaultHandle].info.broadcast_code,                               
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                    
             broadcast_code.c_str(),                                                                                                                 
             ~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                 
             sizeof(devices_[kHubDefaultHandle].info.broadcast_code));                                                                                
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                
```

among other errors of similar nature.

There are a few similar cases elsewhere, although they only produce warnings. I didn't investigate them in detail, but here are the warnings:

```
/home/gekko/Livox-SDK/sample/lidar/main.c:273:7: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=
]
       strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gekko/Livox-SDK/sample/lidar/main.c:273:46: note: length computed here
       strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
                                              ^~~~~~~~~~~~~~

/home/gekko/Livox-SDK/sample/lidar_lvx_file/main.cpp: In function ‘int SetProgramOption(int, const char**)’:                                         
/home/gekko/Livox-SDK/sample/lidar_lvx_file/main.cpp:324:14: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound depends on the lengt
h of the source argument [-Wstringop-overflow=]
       strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gekko/Livox-SDK/sample/lidar_lvx_file/main.cpp:324:52: note: length computed here                                                              
       strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
                                              ~~~~~~^~~~~~~~
In function ‘int SetProgramOption(int, const char**)’,
    inlined from ‘int main(int, const char**)’ at /home/gekko/Livox-SDK/sample_cc/lidar/main.cpp:127:23:
/home/gekko/Livox-SDK/sample_cc/lidar/main.cpp:80:16: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound depends on the length of th
e source argument [-Wstringop-overflow=]
         strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gekko/Livox-SDK/sample_cc/lidar/main.cpp: In function ‘int main(int, const char**)’:
/home/gekko/Livox-SDK/sample_cc/lidar/main.cpp:80:54: note: length computed here
         strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
                                                ~~~~~~^~~~~~~~
In function ‘int SetProgramOption(int, const char**)’,
    inlined from ‘int main(int, const char**)’ at /home/gekko/Livox-SDK/sample_cc/lidar_utc_sync/main.cpp:129:23:                                    
/home/gekko/Livox-SDK/sample_cc/lidar_utc_sync/main.cpp:82:16: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
         strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gekko/Livox-SDK/sample_cc/lidar_utc_sync/main.cpp: In function ‘int main(int, const char**)’:                                                  
/home/gekko/Livox-SDK/sample_cc/lidar_utc_sync/main.cpp:82:54: note: length computed here                                                            
         strncpy(sn_list, optarg, sizeof(char)*(strlen(optarg) + 1));
                                                ~~~~~~^~~~~~~~
```