### PR TITLE
fix: typo in definitions and command_impl mircrosecond -> microsecond

### DIFF
--- a/sdk_core/include/livox_def.h
+++ b/sdk_core/include/livox_def.h
@@ -643,7 +643,7 @@ typedef struct {
   uint8_t month;
   uint8_t day;
   uint8_t hour;
-  uint32_t mircrosecond;
+  uint32_t microsecond;
 } LidarSetUtcSyncTimeRequest;
 
 /**

--- a/sdk_core/src/command_handler/command_impl.cpp
+++ b/sdk_core/src/command_handler/command_impl.cpp
@@ -209,7 +209,7 @@ bool ParseRmcTime(const char* rmc, uint16_t rmc_len, LidarSetUtcSyncTimeRequest*
   }
 
   utc_time_req->hour = hour;
-  utc_time_req->mircrosecond = (minute * 60 * 1000 + second * 1000) * 1000;
+  utc_time_req->microsecond = (minute * 60 * 1000 + second * 1000) * 1000;
   return true;
 }
 


### PR DESCRIPTION
Fix typo which was puzzling me for a while while trying to pin out the reason why sync does not build.

mircrosecond -> microsecond