### PR TITLE
fix: compile error when using libstdc++11

### DIFF
--- a/sdk_core/src/base/thread_base.h
+++ b/sdk_core/src/base/thread_base.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_THREAD_BASE_H_
 #define LIVOX_THREAD_BASE_H_
 #include <atomic>
+#include <memory>
 #include <thread>
 #include "noncopyable.h"
 


### PR DESCRIPTION
When compiling Livox-SDK with libstdc++11 and clang 15, I encounter the following error:
```
In file included from /home/user/repos/Livox-SDK/sdk_core/src/base/thread_base.cpp:25:
/home/user/repos/Livox-SDK/sdk_core/src/base/thread_base.h:46:8: error: no template named 'shared_ptr' in namespace 'std'
  std::shared_ptr<std::thread> thread_;
  ~~~~~^
/home/user/repos/Livox-SDK/sdk_core/src/base/thread_base.cpp:34:18: error: no template named 'make_shared' in namespace 'std'; did you mean 'make_signed'?
  thread_ = std::make_shared<std::thread>(&ThreadBase::ThreadFunc, this);
            ~~~~~^~~~~~~~~~~
                 make_signed
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:1911:12: note: 'make_signed' declared here
    struct make_signed
           ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:1912:24: error: implicit instantiation of undefined template 'std::__make_signed_selector<std::thread, false, false>'
    { typedef typename __make_signed_selector<_Tp>::__type type; };
                       ^
/home/user/repos/Livox-SDK/sdk_core/src/base/thread_base.cpp:34:13: note: in instantiation of template class 'std::make_signed<std::thread>' requested here
  thread_ = std::make_shared<std::thread>(&ThreadBase::ThreadFunc, this);
            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:1847:11: note: template is declared here
    class __make_signed_selector;
          ^
```

This PR fixes the problem by adding the missing `<memory>` header file.