### PR TITLE
Added <memory> include, which was removed from thread <thread>

### DIFF
--- a/sdk_core/src/base/thread_base.h
+++ b/sdk_core/src/base/thread_base.h
@@ -26,6 +26,7 @@
 #define LIVOX_THREAD_BASE_H_
 #include <atomic>
 #include <thread>
+#include <memory>
 #include "noncopyable.h"
 
 namespace livox {


### PR DESCRIPTION
This causes compilation errors relating to `std::shared_ptr`