### PR TITLE
Update thread_base.h

### DIFF
--- a/sdk_core/src/base/thread_base.h
+++ b/sdk_core/src/base/thread_base.h
@@ -25,6 +25,7 @@
 #ifndef LIVOX_THREAD_BASE_H_
 #define LIVOX_THREAD_BASE_H_
 #include <atomic>
+#include <memory>
 #include <thread>
 #include "noncopyable.h"
 


### PR DESCRIPTION
Fixes missing include for std::shared_ptr when building livox-ros2-driver with colcon on Ubuntu 22.04